### PR TITLE
feat: add PHPStan at level 5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,3 +37,6 @@ jobs:
 
       - name: Execute tests
         run: vendor/bin/pest
+
+      - name: Run PHPStan
+        run: vendor/bin/phpstan analyse --memory-limit=256M

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
   "require-dev": {
     "laravel/pint": "^1.21",
     "pestphp/pest": "^3.0",
-    "larapack/dd": "^1.1"
+    "larapack/dd": "^1.1",
+    "phpstan/phpstan": "^2.2"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2e2536c20eb87e11ea9bdbd020cc4050",
+    "content-hash": "3cb4432deda70a00aef5e5a719f9fb35",
     "packages": [
         {
             "name": "brick/math",
@@ -3734,6 +3734,70 @@
                 "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
             },
             "time": "2026-01-25T14:56:51+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.2.2",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e5cc34d491a90e79c216d824f60fe21fd4d93bd6",
+                "reference": "e5cc34d491a90e79c216d824f60fe21fd4d93bd6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-05T09:00:01+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,4 @@
+parameters:
+    level: 5
+    paths:
+        - src

--- a/src/Validators/Validator.php
+++ b/src/Validators/Validator.php
@@ -9,16 +9,12 @@ use Illuminate\Validation\Factory;
 
 abstract class Validator
 {
-    protected static $factory;
+    protected static ?Factory $factory = null;
 
-    public static function instance()
+    public static function instance(): Factory
     {
         if (! static::$factory) {
-            $loader = new FileLoader(
-                new Filesystem,
-                '/Translations'
-            );
-
+            $loader = new FileLoader(new Filesystem, '/Translations');
             $translator = new Translator($loader, 'en');
             static::$factory = new Factory($translator);
         }
@@ -26,28 +22,8 @@ abstract class Validator
         return static::$factory;
     }
 
-    public static function __callStatic($method, $args)
+    public static function make(array $data, array $rules, array $messages = [], array $customAttributes = []): \Illuminate\Validation\Validator
     {
-        $instance = static::instance();
-
-        switch (count($args)) {
-            case 0:
-                return $instance->$method();
-
-            case 1:
-                return $instance->$method($args[0]);
-
-            case 2:
-                return $instance->$method($args[0], $args[1]);
-
-            case 3:
-                return $instance->$method($args[0], $args[1], $args[2]);
-
-            case 4:
-                return $instance->$method($args[0], $args[1], $args[2], $args[3]);
-
-            default:
-                return call_user_func_array([$instance, $method], $args);
-        }
+        return static::instance()->make($data, $rules, $messages, $customAttributes);
     }
 }


### PR DESCRIPTION
## Summary

- Adds `phpstan/phpstan ^2.2` to dev dependencies
- Adds `phpstan.neon` configured at level 5, targeting `src/`
- Fixes the 2 errors PHPStan found by replacing the `__callStatic` magic proxy in `Validator` with an explicit typed `make()` method - cleaner, no suppression needed
- Adds a PHPStan step to CI (runs after tests on every PHP version)

## What was fixed

`Validator::make()` was dispatched via `__callStatic` which PHPStan can't see through. Rather than suppressing with `@phpstan-ignore`, the `__callStatic` switch was replaced with a proper static `make()` method with full type signatures. `$factory` was also typed as `?Factory`.